### PR TITLE
feat: Process DB connection charset option in config

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -7,6 +7,7 @@ return [
         'password' => getenv('DDD_RBD_PASSWORD'),
         'host' => getenv('DDD_RBD_HOST'),
         'driver' => getenv('DDD_RBD_DRIVER'),
+        'charset' => getenv('DDD_RBD_CONNECTION_CHARSET') ?: 'utf8',
     ],
     'loggingType' => getenv('LOGGING_TYPE'),
 ];


### PR DESCRIPTION
Use UTF-8 as a default DB connection charset
issue #60: Provide possibility to specify default charset of a DB connection